### PR TITLE
Fixing masking error with event and site terms

### DIFF
--- a/mera/mera/mera_pymer4.py
+++ b/mera/mera/mera_pymer4.py
@@ -91,17 +91,15 @@ def run_mera(
         )
         cur_model.fit(summary=False)
 
-        # Get random effects
-        event_res_df[cur_im] = (
-            cur_model.ranef[0]
-            if cur_model.ranef[0].size == event_res_df.shape[0]
-            else cur_model.ranef[1]
-        )
-        site_res_df[cur_im] = (
-            cur_model.ranef[0]
-            if cur_model.ranef[0].size == site_res_df.shape[0]
-            else cur_model.ranef[1]
-        )
+        # Get the site and event random effects
+        event_re = cur_model.ranef[0].iloc[:, 0]
+        site_re = cur_model.ranef[1].iloc[:, 0]
+        if site_re.size > event_re.size:
+            raise ValueError("More site terms than event terms")
+
+        # Add random effects to the event, site and rem dataframes
+        event_res_df.loc[event_re.index, cur_im] = event_re
+        site_res_df.loc[site_re.index, cur_im] = site_re
         if mask is None:
             rem_res_df[cur_im] = cur_model.residuals
         else:


### PR DESCRIPTION
Fixes issues where the number of terms did not match up correctly and so produced nans for all values.
Now just uses the index from the cur_model to replace the values in the event and site dataframes.
Adds a sanity check that the event terms are greater than the site terms